### PR TITLE
fix: padding application in the widget

### DIFF
--- a/lib/src/widgets/link_preview.dart
+++ b/lib/src/widgets/link_preview.dart
@@ -161,17 +161,27 @@ class _LinkPreviewState extends State<LinkPreview>
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
         Container(
-          padding: const EdgeInsets.only(
-            bottom: 16,
-            left: 24,
-            right: 24,
-          ),
+          padding: widget.padding?.subtract(
+                EdgeInsets.only(
+                  bottom: widget.padding?.bottom ?? 0,
+                  top: widget.padding?.top ?? 0,
+                ),
+              ) ??
+              const EdgeInsets.only(
+                bottom: 16,
+                left: 24,
+                right: 24,
+              ),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
               if (data.title != null) _titleWidget(data.title!),
               if (data.description != null)
                 _descriptionWidget(data.description!),
+              if (data.title != null && data.description != null)
+                const SizedBox(
+                  height: 8,
+                )
             ],
           ),
         ),
@@ -202,14 +212,16 @@ class _LinkPreviewState extends State<LinkPreview>
           Padding(
             padding: withPadding
                 ? const EdgeInsets.all(0)
-                : const EdgeInsets.symmetric(
-                    horizontal: 24,
-                    vertical: 16,
-                  ),
+                : EdgeInsets.only(
+                    left: _padding.left,
+                    right: _padding.right,
+                    top: _padding.top,
+                    bottom: 0),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 _linkify(),
+                const SizedBox(height: 12),
                 if (withPadding && child != null)
                   shouldAnimate ? _animated(child) : child,
               ],
@@ -240,7 +252,12 @@ class _LinkPreviewState extends State<LinkPreview>
         maxHeight: width,
       ),
       width: width,
-      margin: const EdgeInsets.only(top: 8),
+      margin: const EdgeInsets.only(
+        top: 8,
+        // bottom: widget.padding?.bottom ?? 0,
+        // left: widget.padding?.left ?? 0,
+        // right: widget.padding?.right ?? 0,
+      ),
       child: Image.network(
         url,
         fit: BoxFit.fitWidth,


### PR DESCRIPTION
Hey, @flyerhq I have made the following changes in the padding. #10  I am attaching the screenshot for the padding with different padding values applied from the `ListPreview` constructor. 
```dart
  LinkPreview(
    ...
    padding: const EdgeInsets.all(20),
    ...
  )
```
---
|No padding provided|`const EdgeInsets.all(30),`|`const EdgeInsets.only(left: 30),`|
--- | --- | ---
|![Default Padding](https://user-images.githubusercontent.com/43571990/117547915-df4ae880-b051-11eb-9388-c52455233395.png)|![image](https://user-images.githubusercontent.com/43571990/117548000-394bae00-b052-11eb-87ae-0c4f7db62526.png)|![image](https://user-images.githubusercontent.com/43571990/117548022-68fab600-b052-11eb-98f9-1bc8901222b8.png)|

Please let me know if this can be merged needs change.