### PR TITLE
Add option to specify user agent for link crawling

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,11 +1,13 @@
 import 'dart:async';
 import 'dart:convert';
+
 import 'package:flutter/material.dart' hide Element;
 import 'package:flutter_chat_types/flutter_chat_types.dart'
     show PreviewData, PreviewDataImage;
 import 'package:html/dom.dart' show Document, Element;
 import 'package:html/parser.dart' as parser show parse;
 import 'package:http/http.dart' as http show get;
+
 import 'types.dart';
 
 String _calculateUrl(String baseUrl, String? proxy) {
@@ -156,7 +158,11 @@ Future<String> _getBiggestImageUrl(
 }
 
 /// Parses provided text and returns [PreviewData] for the first found link
-Future<PreviewData> getPreviewData(String text, {String? proxy}) async {
+Future<PreviewData> getPreviewData(
+  String text, {
+  String? proxy,
+  String? userAgent,
+}) async {
   const previewData = PreviewData();
 
   String? previewDataDescription;
@@ -188,7 +194,8 @@ Future<PreviewData> getPreviewData(String text, {String? proxy}) async {
     }
     previewDataUrl = _calculateUrl(url, proxy);
     final uri = Uri.parse(previewDataUrl);
-    final response = await http.get(uri);
+    final response = await http
+        .get(uri, headers: {if (userAgent != null) 'User-Agent': userAgent});
     final document = parser.parse(utf8.decode(response.bodyBytes));
 
     final imageRegexp = RegExp(regexImageContentType);

--- a/lib/src/widgets/link_preview.dart
+++ b/lib/src/widgets/link_preview.dart
@@ -32,6 +32,7 @@ class LinkPreview extends StatefulWidget {
     required this.text,
     this.textStyle,
     this.textWidget,
+    this.userAgent,
     required this.width,
   }) : super(key: key);
 
@@ -95,6 +96,9 @@ class LinkPreview extends StatefulWidget {
 
   /// Widget to display above the preview. If null, defaults to a linkified [text].
   final Widget? textWidget;
+
+  /// User agent to send as GET header when requesting link preview url.
+  final String? userAgent;
 
   /// Width of the [LinkPreview] widget
   final double width;
@@ -160,7 +164,11 @@ class _LinkPreviewState extends State<LinkPreview>
       isFetchingPreviewData = true;
     });
 
-    final previewData = await getPreviewData(text, proxy: widget.corsProxy);
+    final previewData = await getPreviewData(
+      text,
+      proxy: widget.corsProxy,
+      userAgent: widget.userAgent,
+    );
     _handlePreviewDataFetched(previewData);
     return previewData;
   }


### PR DESCRIPTION
I will follow this up with a PR in the chat repository to use the user agent "WhatsApp/2" by default. This is because many dynamic links and other link previews serve specific social media tags for this user agent. For example, Signal also uses this user agent to crawl their link preview data.